### PR TITLE
Ensure Azure artifact downloads into workspace

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -70,7 +70,8 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: node-app
-        path: app
+        path: .
+        merge-multiple: true
 
     - name: Azure Login
       uses: Azure/login@v2.3.0


### PR DESCRIPTION
## Summary
- configure the Azure deploy job to unpack the build artifact into the workspace
- enable merge-multiple so nested node-app archives place the app directory at ./app for deployment

## Testing
- not run (workflow execution requires GitHub Actions environment)


------
https://chatgpt.com/codex/tasks/task_e_68d355d9b5ac832a88613c3f618b53fc